### PR TITLE
Scrum 426 add frontend features for new events on the map

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -414,6 +414,7 @@
     "date": "Date when the event first occurred.",
     "successfully": "Event Created Successfully",
     "success-message": "Your event has been added to the system.",
+    "success-added":"had been added.",
     "errors": {
       "title": "The title must be at least 2 characters long and cannot exceed 50 characters.",
       "latitude": "The latitude must be between -90 and 90.",

--- a/src/locales/nb-NO.json
+++ b/src/locales/nb-NO.json
@@ -416,6 +416,7 @@
     "date": "Dato for når hendelsen først inntraff.",
     "successfully": "Hendelsen ble opprettet",
     "success-message": "Hendelsen din er lagt til i systemet.",
+    "success-added":"har blitt lagt til.",
     "errors": {
       "title": "Tittelen må ha minst 2 tegn og kan ikke overstige 50 tegn.",
       "latitude": "Breddegraden må være mellom -90 og 90.",

--- a/src/views/AdminAddNewEvent.vue
+++ b/src/views/AdminAddNewEvent.vue
@@ -184,9 +184,9 @@
     >
 
       <DialogHeader>
-        <DialogTitle>{{ $t('add-event-info.successfully') }}Event Created Successfully</DialogTitle>
+        <DialogTitle>{{ $t('add-event-info.successfully') }}</DialogTitle>
         <DialogDescription>
-          {{ $t('add-event-info.success-message') }} Your event has been added to the system.
+          {{ $t('add-event-info.success-message') }}
         </DialogDescription>
       </DialogHeader>
 
@@ -198,7 +198,7 @@
             </svg>
           </div>
           <p class="text-lg">
-            <strong>{{ createdEventName }}</strong> has been created successfully.
+            <strong>{{ createdEventName }}</strong> {{ $t('add-event-info.success-added') }}
           </p>
         </div>
       </div>


### PR DESCRIPTION
# Pull Request

## Summary

- The admin can now add events from the admin panel using the map.
---

## Changes Made

- AdminAddNewEvent now shows a map
- AdminAddNewEvent allows updates to backend
- AdminAddNewEvent gives a warning dialog box after adding event.

---

## Screenshots / Visual Changes
 | After |
<img width="1250" alt="Screenshot 2025-04-29 at 15 59 39" src="https://github.com/user-attachments/assets/78bc352f-9b95-4f04-a0b0-a9cf589d87e3" />
<img width="1326" alt="Screenshot 2025-04-29 at 16 00 24" src="https://github.com/user-attachments/assets/f0193a16-9a8f-4123-9cc9-7683028f3aaa" />


---

## Notes for Reviewers

<!-- Optional: extra context for the reviewers, testing instructions, or gotchas -->

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code where necessary
- [ ] I have added tests or updated existing ones
- [x] My changes generate no new warnings
- [x] I have attached relevant screenshots (if UI-related)
