### PR TITLE
bug(map): Fix bug related to travel path and crisis event positioning…

### DIFF
--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -712,7 +712,7 @@ export default defineComponent({
 
       // Add the entire layer group to the map at once
       if (map.value && crisisLayerGroup) {
-        crisisLayerGroup.addTo(map.value);
+        crisisLayerGroup.addTo(map.value as L.Map);
       }
 
       // 4) force a refresh with a slight delay to ensure map is ready
@@ -750,8 +750,8 @@ export default defineComponent({
         try {
           if (map.value && layer) {
             // Check if the layer is still on the map
-            if (map.value.hasLayer(layer)) {
-              map.value.removeLayer(layer);
+            if (map.value.hasLayer(layer as L.Layer)) {
+              map.value.removeLayer(layer as L.Layer);
             }
           }
         } catch (error) {


### PR DESCRIPTION
… on zoom [SCRUM-464]

# Pull Request

## Summary

- The map used to have items stick to the wrong location after zooming. This has been addressed.
---

## Changes Made

- Fix 1: Fix bugs relating to zooming on the map
---

## Screenshots / Visual Changes

<!-- Upload images by dragging & dropping or using Markdown image syntax -->

| Before |

![preview-5](https://github.com/user-attachments/assets/4fab4ee2-d86d-4dba-948c-ef9ffb5b3cf0)

| After |

| ![Before](url) | ![After](url) |
<img width="1088" alt="Screenshot 2025-05-02 at 17 43 00" src="https://github.com/user-attachments/assets/2c23839d-6e96-4676-bc80-5e3ef52f57e6" />

---

## Notes for Reviewers

<!-- Optional: extra context for the reviewers, testing instructions, or gotchas -->

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code where necessary
- [ ] I have added tests or updated existing ones
- [x] My changes generate no new warnings
- [x] I have attached relevant screenshots (if UI-related)


[SCRUM-464]: https://systemutvikling.atlassian.net/browse/SCRUM-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ